### PR TITLE
Add commented out "bindto 0.0.0.0" command

### DIFF
--- a/templates/openocd.cfg
+++ b/templates/openocd.cfg
@@ -1,6 +1,11 @@
 {% if ram.base is undefined or ram.size is undefined %}
   {{ missingvalue("Unable to find RAM to provide OpenOCD a work area") }}
 {% endif %}
+
+# Uncomment next line if you are running OpenOCD on a remote server. Otherwise
+# OpenOCD will only listen on the loopback/localhost interface.
+#bindto 0.0.0.0
+
 # JTAG adapter setup
 adapter_khz     10000
 


### PR DESCRIPTION
We recently had a customer that wanted to run OpenOCD on a remote computer.  Getting it to work meant chasing down this bit of arcane knowledge.  Having the command included as a comment should help future users get the remote connection up and running more quickly.

I think one could make a case that the command should just be included in the template (not commented out) so users don't even hit the initial road-block.  After all, examining the config script is not necessarily the first corrective action a user might take.  9/10 time this will result in a CSD case.

