### PR TITLE
Always generate `-rtos hwthread` configs for multihart

### DIFF
--- a/generate_openocdcfg.py
+++ b/generate_openocdcfg.py
@@ -77,43 +77,6 @@ def get_template(parsed_args):
     return template
 
 
-def is_homogeneous(tree):
-    """Returns True if all harts of the design are homogeneous"""
-    harts = tree.get_by_path("/cpus").children
-
-    num_isas = len({hart.get_field("riscv,isa") for hart in harts})
-
-    return num_isas == 1
-
-
-def isa_is_subset(isa_a, isa_b):
-    """Returns True if ISA a is a subset of ISA b"""
-    bitness_a = isa_a[2:3]
-    bitness_b = isa_b[2:3]
-
-    ext_a = isa_a[3:]
-    ext_b = isa_b[3:]
-
-    for ext in ext_a:
-        if ext not in ext_b:
-            return False
-
-    return bitness_a == bitness_b
-
-
-def boot_hart_is_subset(tree):
-    """Returns True if the requested boot hart implements an ISA subset
-       which is common to all harts"""
-
-    boot_hart = tree.get_by_reference(tree.chosen("metal,boothart")[0])
-    harts = tree.get_by_path("/cpus").children
-
-    boot_hart_isa = boot_hart.get_field("riscv,isa")
-    isas = {hart.get_field("riscv,isa") for hart in harts}
-
-    return all([isa_is_subset(boot_hart_isa, other) for other in isas])
-
-
 def get_ram(tree):
     """Get the base and size of the RAM to use as the OpenOCD work area"""
     metal_ram = tree.chosen("metal,ram")
@@ -170,11 +133,7 @@ def main(argv):
     else:
         connection = "probe"
 
-    if is_homogeneous(dts) or boot_hart_is_subset(dts):
-        num_harts = len(dts.get_by_path("/cpus").children)
-    else:
-        print("WARNING: Heterogeneous design, emitting config for hart 0", file=sys.stderr)
-        num_harts = 1
+    num_harts = len(dts.get_by_path("/cpus").children)
 
     values = {
         "num_harts": num_harts,


### PR DESCRIPTION
Since [we're always building for the greatest common subset ISA](https://github.com/sifive/esdk-settings-generator/pull/5), OpenOCD should always be able to connect to multihart designs with `-rtos hwthread`.