### PR TITLE
parameterize jtag/cjtag scripts

### DIFF
--- a/templates/fpga.cfg
+++ b/templates/fpga.cfg
@@ -19,17 +19,27 @@ if { [ info exists connection ] == 0 } {
   set connection {{ connection }}
 }
 
+if { [ info exists jtag_script ] == 0 } {
+  # If not specified on the cmd line, default to Olimex ARM-USB-TINY-H
+  set jtag_script interface/ftdi/olimex-arm-usb-tiny-h.cfg
+}
+
+if { [ info exists cjtag_script ] == 0 } {
+  # If not specified on the cmd line, default to Olimex ARM-USB-TINY-H
+  set cjtag_script interface/ftdi/olimex-arm-jtag-cjtag.cfg
+}
+
 set debug_config "${protocol}_${connection}"
 # Bring in the correct configuration script for the specified debug config
 switch ${debug_config} {
   jtag_probe {
     echo "Using JTAG"
-    source [find interface/ftdi/olimex-arm-usb-tiny-h.cfg]
+    source [find ${jtag_script}]
     set chain_length 5
   }
   cjtag_probe {
     echo "Using cJTAG"
-    source [find interface/ftdi/olimex-arm-jtag-cjtag.cfg]
+    source [find ${cjtag_script}]
   }
   jtag_tunnel {
     echo "Using JTAG tunnel"


### PR DESCRIPTION
- This PR parameterizes the jtag/cjtag script file for configuring different probes.  
- The intent is to allow support for different Olimex USB probes (for instance, supporting ARM-USB-OCD-H in addition to ARM-USB-TINY-H).  
- This change should be completely benign for all current uses.  
- ARM-USB-TINY-H remains the default configuration. 
- Different behavior is only expected when Freedom Studio (or a CLI user) adds a `-c set jtag_script <script>` or `-c set cjtag_script <script>` to the openocd executable invocation.

This is not required for the upcoming November release of Freedom Studio, so time is **not** of the essence.