### PR TITLE
change "adapter_khz" to "adapter speed"

### DIFF
--- a/templates/openocd.cfg
+++ b/templates/openocd.cfg
@@ -2,7 +2,7 @@
   {{ missingvalue("Unable to find RAM to provide OpenOCD a work area") }}
 {% endif %}
 # JTAG adapter setup
-adapter_khz     {{ adapter_khz }}
+adapter speed {{ adapter_khz }}
 
 set chain_length 5
 

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -18,7 +18,7 @@ if [ ! -f ${OUTPUT_PATH} ] ; then
 fi
 
 >&2 echo "$0: Checking for non-empty ${OUTPUT_PATH}"
-if [ `grep -c 'adapter_khz' ${OUTPUT_PATH}` -ne 1 ] ; then
+if [ `grep -c 'adapter speed' ${OUTPUT_PATH}` -ne 1 ] ; then
         >&2 echo "$0: ERROR ${OUTPUT_PATH} has bad contents"
         exit 2
 fi


### PR DESCRIPTION
Changes the generator to use "adapter speed" instead of the deprecated "adapter_khz" 

The deprecation warning is seen in every FS launch:

![Snag_259ccaa4](https://user-images.githubusercontent.com/43148204/98422159-d136f380-203f-11eb-88bf-46a7a2ff35ce.png)
