### PR TITLE
Update openocd script to use default password.

### DIFF
--- a/templates/openocd.cfg
+++ b/templates/openocd.cfg
@@ -42,9 +42,12 @@ flash bank spi0 fespi {{ flash.mem_base|format_hex }} 0 0 0 $_TARGETNAME_0 {{ fl
 {% endif %}
 
 init
-if { [info exists authkey] } {
-  riscv authdata_write $authkey
+if { [ info exists authkey ] == 0 } {
+  # If not specified on the cmd line, default to '12345678'
+  set authkey 12345678
 }
+
+riscv authdata_write $authkey
 
 if {[ info exists pulse_srst]} {
   ftdi_set_signal nSRST 0


### PR DESCRIPTION
This is my proposal for the updated openocd cfg generator.  I think this should work for all cases without modifying any other part of the core-ip generator framework (but of course I could be wrong).

This change causes the default password (for FPGA generation) to be used when no other password is specified while still maintaining the ability to specify a different password when required (presumably for RTL simulation debug sessions and future hard targets that include the password authentication module.  

The `riscv authdata_write` command is always executed (with the assumption that execution is a nop-op on targets without a password auth module.