### PR TITLE
Use adapter_speed instead of adapter_khz

### DIFF
--- a/templates/openocd.cfg
+++ b/templates/openocd.cfg
@@ -2,7 +2,7 @@
   {{ missingvalue("Unable to find RAM to provide OpenOCD a work area") }}
 {% endif %}
 # JTAG adapter setup
-adapter_khz     {{ adapter_khz }}
+adapter_speed     {{ adapter_khz }}
 
 set chain_length 5
 


### PR DESCRIPTION
This prevents a scary red deprecation warning on every debug launch.

Hope it is not too late to get this into Llama...