### PR TITLE
20MHz JTAG VCU118

### DIFF
--- a/generate_openocdcfg.py
+++ b/generate_openocdcfg.py
@@ -123,7 +123,7 @@ def main(argv):
         parsed_args.dts, followIncludes=True)
 
     if "vcu118" in parsed_args.board:
-        adapter_khz = 1800
+        adapter_khz = 20000
     else:
         adapter_khz = 10000
 


### PR DESCRIPTION
Now that JTAG is moving to be less speed restricted, up the VCU118 default JTAG speed